### PR TITLE
[HttpReceiver] Fixed: Content-Length header is not mandatory

### DIFF
--- a/HttpReceiver/src/commonMain/kotlin/io/manycore/receiver/http/app/route/MailSendRoute.kt
+++ b/HttpReceiver/src/commonMain/kotlin/io/manycore/receiver/http/app/route/MailSendRoute.kt
@@ -41,11 +41,6 @@ fun Routing.setupMailSendRoute() {
                 throw BadRequestException("Bad Request: incorrect content type '$requestContentType', expected '${Application.OctetStream}'")
             }
 
-            val requestContentLength = call.request.contentLength()
-            if (requestContentLength == null || requestContentLength == 0L) {
-                throw BadRequestException("Bad Request: missing or null content length")
-            }
-
             val message = try {
                 withContext(IO) {
                     MimeMessage(call.receiveChannel())


### PR DESCRIPTION
`Transfer-Encoding` could be used instead and would be valid, so the requirement is a bug.